### PR TITLE
fix: dotnet.yml (#2)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,9 +5,9 @@ name: .NET
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ "main", "dev" ]
+    branches: [ main, dev ]
 
 jobs:
   build:


### PR DESCRIPTION
Bring over the fixed workflow file where the double quotes where removed from branch names.